### PR TITLE
fixed navbar anchor with external target

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,12 +235,12 @@
     </div>
     <div class="collapse navbar-collapse" id="myNavbar">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="#about">ABOUT</a></li>
-        <li><a href="http://www.w3schools.com/bootstrap/bootstrap_theme_company.asp">Programa</li></a></li>
-        <li><a href="#services">Actividades</a></li>
-        <li><a href="#portfolio">PORTFOLIO</a></li>
+        <li><a id="innerScroll" href="#about">ABOUT</a></li>
+        <li><a href="http://www.w3schools.com/bootstrap/bootstrap_theme_company.asp" target="_blank">Programa</li></a></li>
+        <li><a id="innerScroll" href="#services">Actividades</a></li>
+        <li><a id="innerScroll" href="#portfolio">PORTFOLIO</a></li>
 
-        <li><a href="#contact">CONTACT</a></li>
+        <li><a id="innerScroll" href="#contact">CONTACT</a></li>
       </ul>
     </div>
   </div>
@@ -376,7 +376,7 @@
   </div>
 </div>
 
-<!--<div id="googleMap" style="height:400px;width:100%;"></div>
+<!--<div id="googleMap" style="height:400px;width:100%;"></div -->
 
 <!-- Add Google Maps -->
 <script src="http://maps.googleapis.com/maps/api/js"></script>
@@ -411,7 +411,7 @@ google.maps.event.addDomListener(window, 'load', initialize);
 <script>
 $(document).ready(function(){
   // Add smooth scrolling to all links in navbar + footer link
-  $(".navbar a, footer a[href='#myPage']").on('click', function(event) {
+  $(".navbar a[id='innerScroll'], footer a[href='#myPage']").on('click', function(event) {
 
     // Prevent default anchor click behavior
     event.preventDefault();


### PR DESCRIPTION
The navbar anchors with external targets did not work because of a default event prevention done when the document is ready. Add `id="innerScroll"` to anchors when needed scrolling inside the page, remove it when linking to external targets.
